### PR TITLE
feat: imagine a simpler StructuredEncryption

### DIFF
--- a/DynamoDbEncryption/dafny/StructuredEncryption/Model/StructuredEncryption.smithy
+++ b/DynamoDbEncryption/dafny/StructuredEncryption/Model/StructuredEncryption.smithy
@@ -47,7 +47,7 @@ integer Version
 
 structure ParsedHeader {
     @required
-    cryptoSchema: CryptoSchema,
+    cryptoSchema: CryptoSchemaMap,
     @required
     algorithmSuiteId: DBEAlgorithmSuiteId,
     @required
@@ -67,9 +67,9 @@ structure EncryptStructureInput {
     @required
     tableName: String,
     @required
-    plaintextStructure: StructuredData,
+    plaintextStructure: StructuredDataMap,
     @required
-    cryptoSchema: CryptoSchema,
+    cryptoSchema: CryptoSchemaMap,
     @required
     cmm: CryptographicMaterialsManagerReference,
 
@@ -90,7 +90,7 @@ structure EncryptStructureInput {
 
 structure EncryptStructureOutput {
     @required
-    encryptedStructure: StructuredData,
+    encryptedStructure: StructuredDataMap,
     @required
     parsedHeader: ParsedHeader,
 }
@@ -106,9 +106,9 @@ structure DecryptStructureInput {
     @required
     tableName: String,
     @required
-    encryptedStructure: StructuredData,
+    encryptedStructure: StructuredDataMap,
     @required
-    authenticateSchema: AuthenticateSchema,
+    authenticateSchema: AuthenticateSchemaMap,
     @required
     cmm: CryptographicMaterialsManagerReference,
 
@@ -126,41 +126,9 @@ structure DecryptStructureOutput {
     //#   - [Structured Data](#structured-data)
     //#   - [Parsed Header](#parsed-header)
     @required
-    plaintextStructure: StructuredData,
+    plaintextStructure: StructuredDataMap,
     @required
     parsedHeader: ParsedHeader,
-}
-
-
-structure StructuredData {
-    // Each "node" in our structured data holds either
-    // a map of more data, a list of more data, or a terminal value
-    //= specification/structured-encryption/structures.md#structured-data
-    //= type=implication
-    //# A Structured Data MUST consist of:
-    // - a [Structured Data Content](#structured-data-content)
-    @required
-    content: StructuredDataContent,
-
-    // Each "node" in our structured data may additionally
-    // have a flat map to express something akin to XML attributes
-    //= specification/structured-encryption/structures.md#structured-data
-    //= type=implication
-    //# - an OPTIONAL map of [Attributes](#structured-data-attributes)
-    attributes: StructuredDataAttributes
-}
-
-//= specification/structured-encryption/structures.md#structured-data-content
-//= type=implication
-//# Structured Data Content is a union of one of three separate structures;
-//# Structured Data Content MUST be one of:
-// - [Terminal Data](#terminal-data)
-// - [Structured Data Map](#structured-data-map)
-// - [Structured Data List](#structured-data-list)
-union StructuredDataContent {
-    Terminal: StructuredDataTerminal,
-    DataList: StructuredDataList,
-    DataMap: StructuredDataMap
 }
 
 // Only handles bytes.
@@ -200,37 +168,7 @@ blob TerminalTypeId
 //# - This map MUST NOT allow duplicate key values
 map StructuredDataMap {
     key: String,
-    value: StructuredData
-}
-
-//= specification/structured-encryption/structures.md#structured-data-list
-//= type=implication
-//# A Structured Data List MUST consist of:
-// - A numerical-indexed array of [Structured Data](#structured-data).
-list StructuredDataList {
-    member: StructuredData
-}
-
-//= specification/structured-encryption/structures.md#structured-data-attributes
-//= type=implication
-//# Structured Data Attributes MUST be map of strings to [Terminal Data](#terminal-data).
-map StructuredDataAttributes {
-    key: String,
     value: StructuredDataTerminal
-}
-
-// This mimics the same structure as StructuredData above,
-// only it's "leaves" are AuthenticateAction instead of Terminal.
-structure CryptoSchema {
-    @required
-    content: CryptoSchemaContent,
-    attributes: CryptoSchemaAttributes
-}
-
-union CryptoSchemaContent {
-    Action: CryptoAction,
-    SchemaMap: CryptoSchemaMap,
-    SchemaList: CryptoSchemaList
 }
 
 @enum([
@@ -251,30 +189,7 @@ string CryptoAction
 
 map CryptoSchemaMap {
     key: String,
-    value: CryptoSchema
-}
-
-list CryptoSchemaList {
-    member: CryptoSchema
-}
-
-map CryptoSchemaAttributes {
-    key: String,
-    value: AuthenticateAction
-}
-
-// This mimics the same structure as StructuredData above,
-// only it's "leaves" are AuthenticateAction instead of Terminal.
-structure AuthenticateSchema {
-    @required
-    content: AuthenticateSchemaContent,
-    attributes: AuthenticateSchemaAttributes
-}
-
-union AuthenticateSchemaContent {
-    Action: AuthenticateAction,
-    SchemaMap: AuthenticateSchemaMap,
-    SchemaList: AuthenticateSchemaList
+    value: CryptoAction
 }
 
 @enum([
@@ -290,15 +205,6 @@ union AuthenticateSchemaContent {
 string AuthenticateAction
 
 map AuthenticateSchemaMap {
-    key: String,
-    value: AuthenticateSchema
-}
-
-list AuthenticateSchemaList {
-    member: AuthenticateSchema
-}
-
-map AuthenticateSchemaAttributes {
     key: String,
     value: AuthenticateAction
 }

--- a/DynamoDbEncryption/dafny/StructuredEncryption/Model/StructuredEncryption.smithy
+++ b/DynamoDbEncryption/dafny/StructuredEncryption/Model/StructuredEncryption.smithy
@@ -131,13 +131,15 @@ structure DecryptStructureOutput {
 structure StructureMember {
     key : String
 }
-structure ListMember {key : Integer}
-structure Attribute {key : String}
+// Not needed now, but easy to add later
+// structure ListMember {key : Integer}
+// structure Attribute {key : String}
 
 union StructuredKey {
     member: StructureMember,
-    attribute: Attribute,
-    list: ListMember
+    // Not needed now, but easy to add later
+    // attribute: Attribute,
+    // list: ListMember
 }
 
 

--- a/DynamoDbEncryption/dafny/StructuredEncryption/Model/StructuredEncryption.smithy
+++ b/DynamoDbEncryption/dafny/StructuredEncryption/Model/StructuredEncryption.smithy
@@ -49,18 +49,6 @@ operation DecryptStructureFlat {
     output: DecryptStructureFlatOutput,
 }
 
-
-//= specification/structured-encryption/decrypt-structure.md#parsed-header
-//= type=implication
-//# This structure MUST contain the following values,
-//# representing the deserialized form of the header of the input encrypted structure:
-//#   - [Algorithm Suite ID](./header.md#format-flavor): The Algorithm Suite ID associated with the Format Flavor on the header.
-//#   - [Crypto Schema](./header.md#encrypt-legend): The Crypto Schema for each signed Terminal,
-//#     calculated using the Crypto Legend in the header, the signature scope used for decryption, and the data in the input structure.
-//#   - [Stored Encryption Context](./header.md#encryption-context): The Encryption Context stored in the header.
-//#   - [Encrypted Data Keys](./header.md#encrypted-data-keys): The Encrypted Data Keys stored in the header.
-//#   - [Encryption Context](#encryption-context): The full Encryption Context used.
-
 structure ParsedHeader {
     @required
     cryptoSchema: CryptoSchemaMap,
@@ -106,11 +94,6 @@ structure EncryptStructureInput {
     encryptionContext: EncryptionContext
 }
 
-//= specification/structured-encryption/encrypt-structure.md#output
-//= type=implication
-//# This operation MUST output the following:
-//# - [Encrypted Structured Data](#encrypted-structured-data)
-//# - [Parsed Header](./decrypt-structure.md#parsed-header)
 structure EncryptStructureOutput {
     @required
     encryptedStructure: StructuredData,


### PR DESCRIPTION
For illustration and discussion purposes only!
Not to be confused for any sort of future reality.

For CryptoSchema and AuthenticateSchema we switch to StructuredKey->ScalarValue
For StructuredData we switch to StructuredKey->StructuredValue
So we can more easily say A.B.C.D ==> ENCRYPT_AND_SIGN
and further, assert that  CryptoSchema.Keys == StructuredData.Keys

We add a new "Flat" layer, for which 
CryptoSchemaContent and AuthenticateSchemaContent are Blob->ScalarValue
For StructuredData we switch to Blob->Blob
In this layer, all attributes are signed, some are encrypted. Encryption context was dealt with by the caller.
