### PR TITLE
fix(TestVectors): define StartUpObject in csproj

### DIFF
--- a/TestVectors/runtimes/net/DbEsdkTestVectors.csproj
+++ b/TestVectors/runtimes/net/DbEsdkTestVectors.csproj
@@ -8,6 +8,7 @@
     <LangVersion>10</LangVersion>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <StartupObject>DbEsdkTestVectors.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
MPL Head updated the TestVectors to be an executable. This means that a Main entrypoint now gets generated in order to run the test vectors as a cli which we are now doing in CI.

However; as a project that depends on the MPL TestVectors, you cannot have two main's
defined in one .csproj. Adding `<StartupObject>DbEsdkTestVectors.Program</StartupObject>` to the
TestVectors' csproj file tells dotnet to use the TestVectors Main as opposed to the one generated by the MPL.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
