### PR TITLE
fix: ...the nightly build. Again.

### DIFF
--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -28,6 +28,7 @@ jobs:
     # Don't run the nightly build on forks
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     strategy:
+      fail-fast: false
       matrix:
         # Break up verification between namespaces over multiple
         # actions to take advantage of parallelization
@@ -82,7 +83,7 @@ jobs:
         uses: ./.github/actions/polymorph_codegen
         with:
           dafny: ${{ env.DAFNY_VERSION }}
-          library: ${{ matrix.library }}
+          library: DynamoDbEncryption
           diff-generated-code: false
 
       - name: Verify ${{ matrix.library }} Dafny code


### PR DESCRIPTION
*Description of changes:*
At some point `.github/actions/polymorph_codegen` composite action broke because of changes in reusable workflows. This doesn't fix all errors in the nightly build but lets it get much further: https://github.com/aws/aws-database-encryption-sdk-dynamodb/actions/runs/10478916837/job/29023359021

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
