### PR TITLE
fix(Java, .NET): Let the MPL define dependencies

### DIFF
--- a/DynamoDbEncryption/runtimes/java/build.gradle.kts
+++ b/DynamoDbEncryption/runtimes/java/build.gradle.kts
@@ -79,14 +79,10 @@ repositories {
 val dynamodb by configurations.creating
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:${dafnyRuntimeJavaVersion}")
-    implementation("software.amazon.smithy.dafny:conversion:${smithyDafnyJavaConversionVersion}")
     implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
 
     implementation(platform("software.amazon.awssdk:bom:2.26.25"))
-    implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")
-    implementation("software.amazon.awssdk:kms")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")

--- a/DynamoDbEncryption/runtimes/net/DynamoDbEncryption.csproj
+++ b/DynamoDbEncryption/runtimes/net/DynamoDbEncryption.csproj
@@ -57,18 +57,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.303.14"/>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.304.16"/>
-    <PackageReference Include="DafnyRuntime" Version="$(DafnyVersion)" />
     <ProjectReference Include="../../../submodules/MaterialProviders/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj"/>
-    <!--
-              System.Collections.Immutable can be removed once dafny.msbuild is updated with
-              https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned
-            -->
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.0"/>
-    <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
-    <PackageReference Include="System.ValueTuple" Version="4.5.0"/>
-
     <Compile Include="Extern/**/*.cs"/>
     <Compile Include="Generated/**/*.cs"/>
     <Compile Include="src/**/*.cs"/>

--- a/DynamoDbEncryption/runtimes/net/tests/Test-DynamoDbEncryption.csproj
+++ b/DynamoDbEncryption/runtimes/net/tests/Test-DynamoDbEncryption.csproj
@@ -11,16 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--
-      System.Collections.Immutable can be removed once dafny.msbuild is updated with
-      https://github.com/dafny-lang/dafny.msbuild/pull/10 and versioned
-    -->
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
-    <!-- Work around for dafny-lang/dafny/issues/1951; remove once resolved -->
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="../DynamoDbEncryption.csproj" />
     <Compile Include="TestsFromDafny.cs" />
   </ItemGroup>

--- a/Examples/runtimes/java/DynamoDbEncryption/build.gradle.kts
+++ b/Examples/runtimes/java/DynamoDbEncryption/build.gradle.kts
@@ -68,17 +68,10 @@ repositories {
 
 dependencies {
     implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${ddbecVersion}")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
-
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))
     implementation("software.amazon.awssdk:arns")
     implementation("software.amazon.awssdk:auth")
-    implementation("software.amazon.awssdk:dynamodb")
-    implementation("software.amazon.awssdk:dynamodb-enhanced")
-    implementation("software.amazon.awssdk:kms")
     implementation("software.amazon.awssdk:sts")
-
-    implementation("org.bouncycastle:bcprov-jdk18on:1.72")
 
     // https://mvnrepository.com/artifact/org.testng/testng
     testImplementation("org.testng:testng:7.5")

--- a/Examples/runtimes/java/Migration/DDBECToAWSDBE/build.gradle.kts
+++ b/Examples/runtimes/java/Migration/DDBECToAWSDBE/build.gradle.kts
@@ -67,12 +67,9 @@ repositories {
 
 dependencies {
     implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${ddbecVersion}")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
 
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))
-    implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")
-    implementation("software.amazon.awssdk:kms")
 
     // To support legacy configuration
     implementation("com.amazonaws:aws-java-sdk-dynamodb:1.12.409")

--- a/Examples/runtimes/java/Migration/PlaintextToAWSDBE/build.gradle.kts
+++ b/Examples/runtimes/java/Migration/PlaintextToAWSDBE/build.gradle.kts
@@ -67,12 +67,8 @@ repositories {
 
 dependencies {
     implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${ddbecVersion}")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
-
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))
-    implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")
-    implementation("software.amazon.awssdk:kms")
 
     // https://mvnrepository.com/artifact/org.testng/testng
     testImplementation("org.testng:testng:7.5")

--- a/TestVectors/runtimes/java/build.gradle.kts
+++ b/TestVectors/runtimes/java/build.gradle.kts
@@ -86,17 +86,12 @@ repositories {
 val dynamodb by configurations.creating
 
 dependencies {
-    implementation("org.dafny:DafnyRuntime:${dafnyRuntimeJavaVersion}")
-    implementation("software.amazon.smithy.dafny:conversion:${smithyDafnyJavaConversionVersion}")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${mplVersion}")
     implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${ddbecVersion}")
     implementation("software.amazon.cryptography:TestAwsCryptographicMaterialProviders:${mplVersion}")
 
     implementation(platform("software.amazon.awssdk:bom:2.26.25"))
-    implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")
-    implementation("software.amazon.awssdk:core:2.26.25")
-    implementation("software.amazon.awssdk:kms")
+    implementation("software.amazon.awssdk:core")
     testImplementation("com.amazonaws:DynamoDBLocal:2.+")
     // This is where we gather the SQLLite files to copy over
     dynamodb("com.amazonaws:DynamoDBLocal:2.+")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Normally, if a package directly uses classes/objects/references/symbols from an other package,
it should declare a direct dependency on that package,
rather than relying on it being in the symbol resolution via a transitive dependency.

However,
the DB-ESDK and the MPL are strongly linked.
Additionally, 
they are owned/maintained by the same team,
AWS Crypto Tools.

AWS Crypto Tools can reduce the amount of effort needed
to update the KMS, DDB, Bouncy Castle, and other dependencies 
common to both the MPL and the DB-ESDK by breaking the convention
described above.

This helps our customers by reducing Crypto Tools maintenance efforts,
freeing us to innovate or investigate issues.

Closes https://github.com/aws/aws-database-encryption-sdk-dynamodb/pull/1470


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
