### PR TITLE
fix(shared-cache): block shared cache for beacons

### DIFF
--- a/DynamoDbEncryption/dafny/DynamoDbEncryption/src/ConfigToInfo.dfy
+++ b/DynamoDbEncryption/dafny/DynamoDbEncryption/src/ConfigToInfo.dfy
@@ -119,6 +119,12 @@ module SearchConfigToInfo {
       && config.multi.keyFieldName in outer.attributeActionsOnEncrypt
       && outer.attributeActionsOnEncrypt[config.multi.keyFieldName] == SE.ENCRYPT_AND_SIGN
       ==> output.Failure?
+    ensures
+      && config.multi?
+      && config.multi.cache.Some?
+      && config.multi.cache.value.Shared?
+      ==> output.Failure?
+
   {
     var mplR := MaterialProviders.MaterialProviders();
     var mpl :- mplR.MapFailure(e => AwsCryptographyMaterialProviders(e));
@@ -139,7 +145,7 @@ module SearchConfigToInfo {
 
     var cache;
     if cacheType.Shared? {
-      cache := cacheType.Shared;
+      return Failure(E("Scan Beacons and Searchable Encryption do NOT support Shared caches."));
     } else {
       //= specification/searchable-encryption/search-config.md#key-store-cache
       //# For a Beacon Key Source a [CMC](../../submodules/MaterialProviders/aws-encryption-sdk-specification/framework/cryptographic-materials-cache.md)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Block shared cache for Searchable Encryption / Beacons
- Tested this by running complex beacon example in Rust with `MultiKeyStore` and shared cache by updating `beacon_config.rs`. Error: 
```
thread 'main' panicked at src/intercept.rs:88:63:
called `Result::unwrap()` on an `Err` value: DynamoDbEncryptionError { error: DynamoDbEncryptionException { message: "Scan Beacons and Searchable Encryption do NOT support Shared caches." } }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
