### PR TITLE
chore(go): Add decrypt manifest for Go 

### DIFF
--- a/TestVectors/dafny/DDBEncryption/src/TestVectors.dfy
+++ b/TestVectors/dafny/DDBEncryption/src/TestVectors.dfy
@@ -102,6 +102,7 @@ module {:options "-functionSyntax:4"} DdbEncryptionTestVectors {
       var _ :- expect DecryptManifest.Decrypt("decrypt_dotnet_33a.json", keyVectors);
       var _ :- expect DecryptManifest.Decrypt("decrypt_java_33a.json", keyVectors);
       var _ :- expect DecryptManifest.Decrypt("decrypt_rust_38.json", keyVectors);
+      var _ :- expect DecryptManifest.Decrypt("decrypt_go_38.json", keyVectors);
       var _ :- expect WriteManifest.Write("encrypt.json");
       var _ :- expect EncryptManifest.Encrypt("encrypt.json", "decrypt.json", "java", "3.3", keyVectors);
       var _ :- expect DecryptManifest.Decrypt("decrypt.json", keyVectors);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Ran make `transpile_go`, `polymorph_go` and `test_go`. 
- Got decrypt.json in runtimes/go/testFromDafny-go which I copied to runtimes/java and renamed to `decrypt_go_38.json`
- Added `decrypt_go_38.json` to DdbEncryptionTestVectors.RunAllTests like other runtimes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
