### PR TITLE
chore(dotnet): copy all the JSON for testvectors CI 

### DIFF
--- a/.github/workflows/ci_test_vector_net.yml
+++ b/.github/workflows/ci_test_vector_net.yml
@@ -97,7 +97,6 @@ jobs:
       - name: Test TestVectors on .NET 6.0
         working-directory: ./${{matrix.library}}/runtimes/net
         run: |
-          cp ../java/decrypt_java_*.json ../java/decrypt_dotnet_*.json ../java/decrypt_rust_*.json ../java/large_records.json .
-          dotnet run
           cp ../java/*.json .
+          dotnet run
           dotnet run --framework net6.0

--- a/.github/workflows/dafny_interop_test_vector_net.yml
+++ b/.github/workflows/dafny_interop_test_vector_net.yml
@@ -108,7 +108,6 @@ jobs:
       - name: Test TestVectors on .NET 6.0
         working-directory: ./${{matrix.library}}/runtimes/net
         run: |
-          cp ../java/decrypt_java_*.json ../java/decrypt_dotnet_*.json ../java/decrypt_rust_*.json .
-          dotnet run
           cp ../java/*.json .
+          dotnet run
           dotnet run --framework net6.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Current CI only copies `../java/decrypt_java_*.json ../java/decrypt_dotnet_*.json ../java/decrypt_rust_*.json ../java/large_records.json .` We do also need to copy files like `data.json`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
