### PR TITLE
chore(cfn): add DescribeTable permission for legacy DDBEC support

### DIFF
--- a/cfn/CI.yaml
+++ b/cfn/CI.yaml
@@ -256,6 +256,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:Query
               - dynamodb:UpdateItem
+              - dynamodb:DescribeTable
             Resource:
               - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TableName}"
               - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TableName}/index/*"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This allows the DB-ESDK for Python to test the legacy extern behavior.
- See: https://docs.aws.amazon.com/database-encryption-sdk/latest/devguide/python-using.html#python-helpers
- To use the client helper classes in DDBEC, the caller must have permission to call the DynamoDB DescribeTable operation on the target table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
