### PR TITLE
chore(go): add non bmp to migration examples 

### DIFF
--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step1.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step1.go
@@ -36,7 +36,7 @@ primary key configuration:
   - Partition key is named "partition_key" with type (S)
   - Sort key is named "sort_key" with type (S)
 */
-func MigrationStep1(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyReadValue string) error {
+func MigrationStep1(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyReadValue, encryptedAndSignedValue, signOnlyValue, doNothingValue string) error {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	utils.HandleError(err)
 
@@ -66,9 +66,6 @@ func MigrationStep1(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue
 
 	// 3. Put an item into your table.
 	//    This item will be stored in plaintext.
-	encryptedAndSignedValue := "this will be encrypted and signed"
-	signOnlyValue := "this will never be encrypted, but it will be signed"
-	doNothingValue := "this will never be encrypted nor signed"
 	item := map[string]types.AttributeValue{
 		"partition_key": &types.AttributeValueMemberS{Value: partitionKeyValue},
 		"sort_key":      &types.AttributeValueMemberN{Value: sortKeyWriteValue},

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step1_test.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step1_test.go
@@ -3,6 +3,7 @@ package awsdbe
 import (
 	"testing"
 
+	plaintexttoawsdbe "github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/migration/PlaintextToAWSDBE"
 	"github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/migration/PlaintextToAWSDBE/plaintext"
 	"github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/utils"
 	"github.com/google/uuid"
@@ -15,31 +16,31 @@ func TestMigrationStep1(t *testing.T) {
 	sortKeys := []string{"0", "1", "2", "3"}
 
 	// Successfully executes Step 1
-	err := MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[1])
+	err := MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[1], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 0 has succeeded
-	err = plaintext.MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[0])
+	err = plaintext.MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[0], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 1 with sortReadValue=0, Then: Success (i.e. can read plaintext values)
-	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[0])
+	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[0], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 2 has succeeded
-	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[2])
+	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[2], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 1 with sortReadValue=2, Then: Success (i.e. can read encrypted values)
-	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[2])
+	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[2], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 3 has succeeded
-	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[3])
+	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[3], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 1 with sortReadValue=3, Then: Success (i.e. can read encrypted values)
-	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[3])
+	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[3], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Cleanup

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step2.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step2.go
@@ -38,7 +38,7 @@ primary key configuration:
   - Partition key is named "partition_key" with type (S)
   - Sort key is named "sort_key" with type (S)
 */
-func MigrationStep2(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyReadValue string) error {
+func MigrationStep2(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyReadValue, encryptedAndSignedValue, signOnlyValue, doNothingValue string) error {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	utils.HandleError(err)
 
@@ -64,9 +64,6 @@ func MigrationStep2(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue
 
 	// 3. Put an item into your table.
 	//    This item will be encrypted.
-	encryptedAndSignedValue := "this will be encrypted and signed"
-	signOnlyValue := "this will never be encrypted, but it will be signed"
-	doNothingValue := "this will never be encrypted nor signed"
 	item := map[string]types.AttributeValue{
 		"partition_key": &types.AttributeValueMemberS{Value: partitionKeyValue},
 		"sort_key":      &types.AttributeValueMemberN{Value: sortKeyWriteValue},

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step2_test.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step2_test.go
@@ -3,6 +3,7 @@ package awsdbe
 import (
 	"testing"
 
+	plaintexttoawsdbe "github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/migration/PlaintextToAWSDBE"
 	"github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/migration/PlaintextToAWSDBE/plaintext"
 	"github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/utils"
 	"github.com/google/uuid"
@@ -15,31 +16,31 @@ func TestMigrationStep2(t *testing.T) {
 	sortKeys := []string{"0", "1", "2", "3"}
 
 	// Successfully executes Step 2
-	err := MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[2])
+	err := MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[2], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 0 has succeeded
-	err = plaintext.MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[0])
+	err = plaintext.MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[0], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 2 with sortReadValue=0, Then: Success (i.e. can read plaintext values)
-	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[0])
+	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[0], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 1 has succeeded
-	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[1])
+	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[1], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 2 with sortReadValue=1, Then: Success (i.e. can read encrypted values)
-	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[1])
+	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[1], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 3 has succeeded
-	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[3])
+	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[3], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 2 with sortReadValue=3, Then: Success (i.e. can read encrypted values)
-	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[3])
+	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[3], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Cleanup

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step3.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step3.go
@@ -31,7 +31,7 @@ primary key configuration:
   - Partition key is named "partition_key" with type (S)
   - Sort key is named "sort_key" with type (S)
 */
-func MigrationStep3(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyReadValue string) error {
+func MigrationStep3(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyReadValue, encryptedAndSignedValue, signOnlyValue, doNothingValue string) error {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	utils.HandleError(err)
 
@@ -61,9 +61,6 @@ func MigrationStep3(kmsKeyID, ddbTableName, partitionKeyValue, sortKeyWriteValue
 
 	// 3. Put an item into your table.
 	//    This item will be encrypted.
-	encryptedAndSignedValue := "this will be encrypted and signed"
-	signOnlyValue := "this will never be encrypted, but it will be signed"
-	doNothingValue := "this will never be encrypted nor signed"
 	item := map[string]types.AttributeValue{
 		"partition_key": &types.AttributeValueMemberS{Value: partitionKeyValue},
 		"sort_key":      &types.AttributeValueMemberN{Value: sortKeyWriteValue},

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step3_test.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/awsdbe/step3_test.go
@@ -3,6 +3,7 @@ package awsdbe
 import (
 	"testing"
 
+	plaintexttoawsdbe "github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/migration/PlaintextToAWSDBE"
 	"github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/migration/PlaintextToAWSDBE/plaintext"
 	"github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/utils"
 	"github.com/google/uuid"
@@ -15,31 +16,31 @@ func TestMigrationStep3(t *testing.T) {
 	sortKeys := []string{"0", "1", "2", "3"}
 
 	// Successfully executes Step 3
-	err := MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[3])
+	err := MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[3], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 0 has succeeded
-	err = plaintext.MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[0])
+	err = plaintext.MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[0], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 3 with sortReadValue=0, Then: should panic (cannot read plaintext values)
-	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[0])
+	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[0], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.AssertServiceError(err, "DynamoDB", "GetItem", "Encrypted item missing expected header and footer attributes")
 
 	// Given: Step 1 has succeeded
-	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[1])
+	err = MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[1], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 3 with sortReadValue=1, Then: should error out (cannot read plaintext values)
-	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[1])
+	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[1], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.AssertServiceError(err, "DynamoDB", "GetItem", "Encrypted item missing expected header and footer attributes")
 
 	// Given: Step 2 has succeeded
-	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[2])
+	err = MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[2], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 3 with sortReadValue=2, Then: Success (can read encrypted values)
-	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[2])
+	err = MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[2], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Cleanup

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/migrationutils.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/migrationutils.go
@@ -7,6 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
+const (
+	EncryptedAndSignedValue = "this will be encrypted and signed"
+	SignOnlyValue           = "this will never be encrypted, but it will be signed"
+	DoNothingValue          = "this will never be encrypted nor signed"
+)
+
 func VerifyReturnedItem(result *dynamodb.GetItemOutput, partitionKeyValue, sortKeyValue, encryptedAndSignedValue, signOnlyValue, doNothingValue string) error {
 	returnedPartitionKey, ok := result.Item["partition_key"].(*types.AttributeValueMemberS)
 	if !ok {

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/migrationutils.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/migrationutils.go
@@ -8,9 +8,9 @@ import (
 )
 
 const (
-	EncryptedAndSignedValue = "this will be encrypted and signed"
-	SignOnlyValue           = "this will never be encrypted, but it will be signed"
-	DoNothingValue          = "this will never be encrypted nor signed"
+	EncryptedAndSignedValue = "􏨾먱龹龱𐀂﹌𐀁𐀂𐀂𐀁. This will be encrypted and signed. 􏨾먱龹龱𐀂﹌𐀁𐀂𐀂𐀁"
+	SignOnlyValue           = "􏨾먱龹龱𐀂﹌𐀁𐀂𐀂𐀁. This will never be encrypted, but it will be signed. 􏨾먱龹龱𐀂﹌𐀁𐀂𐀂𐀁."
+	DoNothingValue          = "􏨾먱龹龱𐀂﹌𐀁𐀂𐀂𐀁. This will never be encrypted nor signed. 􏨾먱龹龱𐀂﹌𐀁𐀂𐀂𐀁."
 )
 
 func VerifyReturnedItem(result *dynamodb.GetItemOutput, partitionKeyValue, sortKeyValue, encryptedAndSignedValue, signOnlyValue, doNothingValue string) error {

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/plaintext/step0.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/plaintext/step0.go
@@ -31,7 +31,7 @@ primary key configuration:
   - Partition key is named "partition_key" with type (S)
   - Sort key is named "sort_key" with type (S)
 */
-func MigrationStep0(ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyReadValue string) error {
+func MigrationStep0(ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyReadValue, encryptedAndSignedValue, signOnlyValue, doNothingValue string) error {
 	// 1. Create a standard DynamoDB client
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	utils.HandleError(err)
@@ -39,9 +39,6 @@ func MigrationStep0(ddbTableName, partitionKeyValue, sortKeyWriteValue, sortKeyR
 
 	// 2. Put an example item into DynamoDB table
 	//    This item will be stored in plaintext.
-	encryptedAndSignedValue := "this will be encrypted and signed"
-	signOnlyValue := "this will never be encrypted, but it will be signed"
-	doNothingValue := "this will never be encrypted nor signed"
 	item := map[string]types.AttributeValue{
 		"partition_key": &types.AttributeValueMemberS{Value: partitionKeyValue},
 		"sort_key":      &types.AttributeValueMemberN{Value: sortKeyWriteValue},

--- a/Examples/runtimes/go/migration/PlaintextToAWSDBE/plaintext/step0_test.go
+++ b/Examples/runtimes/go/migration/PlaintextToAWSDBE/plaintext/step0_test.go
@@ -3,6 +3,7 @@ package plaintext
 import (
 	"testing"
 
+	plaintexttoawsdbe "github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/migration/PlaintextToAWSDBE"
 	"github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/migration/PlaintextToAWSDBE/awsdbe"
 	"github.com/aws/aws-database-encryption-sdk-dynamodb/releases/go/dynamodb-esdk/examples/utils"
 	"github.com/google/uuid"
@@ -15,29 +16,29 @@ func TestMigrationStep0(t *testing.T) {
 	sortKeys := []string{"0", "1", "2", "3"}
 
 	// Successfully executes step 0
-	err := MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[0])
+	err := MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[0], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 1 has succeeded
-	err = awsdbe.MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[1])
+	err = awsdbe.MigrationStep1(kmsKeyID, tableName, partitionKey, sortKeys[1], sortKeys[1], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 0 with sortReadValue=1, Then: Success (i.e. can read plaintext values)
-	err = MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[1])
+	err = MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[1], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// Given: Step 2 has succeeded
-	err = awsdbe.MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[2])
+	err = awsdbe.MigrationStep2(kmsKeyID, tableName, partitionKey, sortKeys[2], sortKeys[2], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.HandleError(err)
 
 	// When: Execute Step 0 with sortReadValue=2, Then: should error out when reading encrypted items.
-	err = MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[2])
+	err = MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[2], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.AssertErrorMessage(err, "attribute1 is not a string attribute")
 
 	// Given: Step 3 has succeeded (if it exists)
-	awsdbe.MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[3])
+	awsdbe.MigrationStep3(kmsKeyID, tableName, partitionKey, sortKeys[3], sortKeys[3], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	// When: Execute Step 0 with sortReadValue=3, Then: should error out
-	err = MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[3])
+	err = MigrationStep0(tableName, partitionKey, sortKeys[0], sortKeys[3], plaintexttoawsdbe.EncryptedAndSignedValue, plaintexttoawsdbe.SignOnlyValue, plaintexttoawsdbe.SignOnlyValue)
 	utils.AssertErrorMessage(err, "attribute1 is not a string attribute")
 
 	// Cleanup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[migrationutils.go](https://github.com/aws/aws-database-encryption-sdk-dynamodb/pull/1968/files#diff-7c3557bffab5eb1274ff49d789d6005ab104fdcef1d8b782c0f6a93237f4c36c) is the only file that makes changes to add non bmp character. All other is just refactoring for maintainability. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
