### PR TITLE
fix(ci): show real current version in duplicate-deps error message

### DIFF
--- a/.github/workflows/rust_duplicate_deps.yml
+++ b/.github/workflows/rust_duplicate_deps.yml
@@ -101,8 +101,10 @@ jobs:
               # Repo-relative path to the offending Cargo.toml, and the line to change.
               cargo_path="$dir/Cargo.toml"
               cargo_line=$(grep -nE "^$crate[[:space:]]*=" Cargo.toml | head -1)
-              cur=$(printf '%s' "$cargo_line" | grep -oE '[0-9][0-9.]+' | head -1)
               lineno=$(printf '%s' "$cargo_line" | cut -d: -f1)
+              # Strip grep -n's "N:" line-number prefix before reading the
+              # version, otherwise the line number is misread as the version.
+              cur=$(printf '%s' "${cargo_line#*:}" | grep -oE '[0-9][0-9.]+' | head -1)
 
               echo "::error::$crate versions aren't consistent. Fix: pin it to $want in $cargo_path."
               echo "In $cargo_path line $lineno, change"


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:

Fixes the error message emitted by the `Check for duplicate aws-lc-sys / aws-lc-fips-sys` step in `rust_duplicate_deps.yml`.

When a duplicate is found, the step prints a suggested diff for the offending `Cargo.toml`. It parsed the "current" version from the output of `grep -n`, which still carries the `N:` line-number prefix, so `grep -oE '[0-9][0-9.]+' | head -1` grabbed the line number instead of the version. A dependency on line 18 was reported as `aws-lc-sys = "18"` rather than its real version. The prefix is now stripped before reading the version, so the message shows the actual current version.

Same fix as the companion PRs in aws-cryptographic-material-providers-library and aws-encryption-sdk, which share this workflow.

### Squash/merge commit message, if applicable:

```
(dafny/java/python/dotnet/go/rust): 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
